### PR TITLE
Support pysam>=0.9 and samtools>=1.3

### DIFF
--- a/bin/TEtranscripts
+++ b/bin/TEtranscripts
@@ -207,7 +207,12 @@ def readInAlignment(filename, format, sortByPos,prj_name):
 
                 cur_time = time.time()
                 bam_tmpfile = '.'+str(cur_time)
-                pysam.sort("-n",filename,bam_tmpfile)
+                if tuple(map(int, pysam.__version__.split(".")[0:2])) < tuple([0, 9]):
+                    # pysam < 0.9 / samtools < 1.3
+                    pysam.sort("-n",filename,bam_tmpfile)
+                else:
+                    # pysam >= 0.9 / samtools >= 1.3
+                    pysam.sort("-n","-o",bam_tmpfile+".bam",filename)
                 #samfile = pysam.AlignmentFile(samtools_in.stdout,'r')
                 samfile = pysam.AlignmentFile(bam_tmpfile+".bam",'r')
                 if len(samfile.header) ==0:


### PR DESCRIPTION
This PR solves the `pysam` error when using pysam>=0.9.

The cause of the problem is that `pysam` 0.9 uses `samtools` 1.3 which has a changed interface for `sort` command. 
